### PR TITLE
Fix #23 Crash when right clicking apiarist pipe with Forestry 3.5.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,9 +59,7 @@ dependencies {
     compile "codechicken:CodeChickenCore:1.7.10-1.0.6.43:dev"
     compile "codechicken:NotEnoughItems:1.7.10-1.0.4.106:dev"
     compile "codechicken:ForgeMultipart:1.7.10-1.1.1.320:dev"
-    compile("net.sengir.forestry:forestry_1.7.10:3.6.0.576-unstable:api") {
-        exclude module: "buildcraft"
-    }
+    compile "net.sengir.forestry:forestry_1.7.10:3.5.7.16:api"
     compile "qmunity:QmunityLib:0.1.109:deobf"
     compile("com.enderio:EnderIO:1.7.10-2.2.6.324:dev") {
         exclude module: "buildcraft"
@@ -70,6 +68,7 @@ dependencies {
     compile ("appeng:appliedenergistics2:rv2-beta-8:dev") {
         transitive = false
     }
+    compile name: "buildcraft", version: "7.0.6", classifier: "dev"
 }
 
 minecraft {

--- a/common/buildcraft/compat/CompatModuleForestry.java
+++ b/common/buildcraft/compat/CompatModuleForestry.java
@@ -9,6 +9,10 @@ import cpw.mods.fml.common.event.FMLMissingMappingsEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraftforge.client.MinecraftForgeClient;
 
+import forestry.api.apiculture.IBeeRoot;
+import forestry.api.genetics.AlleleManager;
+import forestry.api.genetics.IAlleleRegistry;
+
 import buildcraft.BuildCraftTransport;
 import buildcraft.compat.forestry.pipes.PipeItemsPropolis;
 import buildcraft.compat.forestry.schematics.SchematicForestryFarmBlock;
@@ -21,6 +25,8 @@ import buildcraft.transport.TransportProxyClient;
 
 public class CompatModuleForestry extends CompatModuleBase
 {
+    public static IBeeRoot beeRoot;
+
     /** Pipe used to sort bees from Forestry. */
     private static Item pipeItemsPropolis;
     
@@ -36,6 +42,16 @@ public class CompatModuleForestry extends CompatModuleBase
 
     @Override
     public void init() {
+        IAlleleRegistry alleleRegistry = AlleleManager.alleleRegistry;
+        if (alleleRegistry == null) {
+            return;
+        }
+
+        beeRoot = (IBeeRoot) alleleRegistry.getSpeciesRoot("rootBees");
+        if (beeRoot == null) {
+            return;
+        }
+
         ItemStack propolis = GameRegistry.findItemStack(name(), "propolis", 1);
 
         if (propolis != null && propolis.getItem() != null) {

--- a/common/buildcraft/compat/forestry/pipes/EnumFilterType.java
+++ b/common/buildcraft/compat/forestry/pipes/EnumFilterType.java
@@ -8,8 +8,7 @@ import net.minecraft.util.IIcon;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 
-import forestry.api.apiculture.BeeManager;
-
+import buildcraft.compat.CompatModuleForestry;
 import buildcraft.texture.TextureManager;
 
 public enum EnumFilterType {
@@ -18,10 +17,10 @@ public enum EnumFilterType {
 
 	public static EnumFilterType getType(ItemStack stack) {
 
-		if (BeeManager.beeRoot.isMember(stack)) {
-			if (BeeManager.beeRoot.isDrone(stack)) {
+		if (CompatModuleForestry.beeRoot.isMember(stack)) {
+			if (CompatModuleForestry.beeRoot.isDrone(stack)) {
 				return DRONE;
-			} else if (BeeManager.beeRoot.isMated(stack)) {
+			} else if (CompatModuleForestry.beeRoot.isMated(stack)) {
 				return QUEEN;
 			} else {
 				return PRINCESS;

--- a/common/buildcraft/compat/forestry/pipes/PipeItemsPropolis.java
+++ b/common/buildcraft/compat/forestry/pipes/PipeItemsPropolis.java
@@ -13,13 +13,13 @@ import net.minecraftforge.common.util.ForgeDirection;
 
 import buildcraft.BuildCraftCompat;
 import buildcraft.api.core.IIconProvider;
+import buildcraft.compat.CompatModuleForestry;
 import buildcraft.gui.GuiIds;
 import buildcraft.transport.BlockGenericPipe;
 import buildcraft.transport.Pipe;
 import buildcraft.transport.PipeTransportItems;
 import buildcraft.transport.TransportConstants;
 import buildcraft.transport.pipes.events.PipeEventItem;
-import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.IBee;
 import forestry.api.genetics.IAllele;
 
@@ -98,7 +98,7 @@ public class PipeItemsPropolis extends Pipe<PipeTransportItems> {
 		IBee bee = null;
 
 		if (type != EnumFilterType.ITEM) {
-			bee = BeeManager.beeRoot.getMember(event.item.getItemStack());
+			bee = CompatModuleForestry.beeRoot.getMember(event.item.getItemStack());
 		}
 
 		// Filtered outputs

--- a/common/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
+++ b/common/buildcraft/compat/forestry/pipes/gui/GuiPropolisPipe.java
@@ -15,6 +15,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraftforge.common.util.ForgeDirection;
 
+import buildcraft.compat.CompatModuleForestry;
 import buildcraft.compat.forestry.pipes.EnumFilterType;
 import buildcraft.compat.forestry.pipes.PipeItemsPropolis;
 import buildcraft.compat.forestry.pipes.PipeLogicPropolis;
@@ -22,7 +23,6 @@ import buildcraft.core.lib.gui.GuiBuildCraft;
 import buildcraft.core.lib.gui.tooltips.ToolTip;
 import buildcraft.core.lib.gui.tooltips.ToolTipLine;
 import buildcraft.core.lib.gui.widgets.Widget;
-import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.EnumBeeType;
 import forestry.api.apiculture.IAlleleBeeSpecies;
 import forestry.api.apiculture.IApiaristTracker;
@@ -56,7 +56,7 @@ public class GuiPropolisPipe extends GuiBuildCraft {
 			container.addWidget(new TypeFilterSlot(8, 18 + i * 18, ForgeDirection.values()[i], pipeLogic));
 		}
 
-		IApiaristTracker tracker = BeeManager.beeRoot.getBreedingTracker(player.worldObj, player.getGameProfile());
+		IApiaristTracker tracker = CompatModuleForestry.beeRoot.getBreedingTracker(player.worldObj, player.getGameProfile());
 		for (int i = 0; i < 6; i++) {
 			for (int pattern = 0; pattern < 3; pattern++) {
 				for (int allele = 0; allele < 2; allele++) {

--- a/common/buildcraft/gui/CompatGuiHandler.java
+++ b/common/buildcraft/gui/CompatGuiHandler.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.common.network.IGuiHandler;
 import forestry.api.apiculture.BeeManager;
 import forestry.api.apiculture.IApiaristTracker;
 
+import buildcraft.compat.CompatModuleForestry;
 import buildcraft.compat.forestry.pipes.PipeHelper;
 import buildcraft.compat.forestry.pipes.PipeItemsPropolis;
 import buildcraft.compat.forestry.pipes.gui.ContainerPropolisPipe;
@@ -31,7 +32,7 @@ public class CompatGuiHandler implements IGuiHandler {
 
 		switch (id) {
 			case GuiIds.PIPE_APIARIST: {
-				IApiaristTracker tracker = BeeManager.beeRoot.getBreedingTracker(world, player.getGameProfile());
+				IApiaristTracker tracker = CompatModuleForestry.beeRoot.getBreedingTracker(world, player.getGameProfile());
 				tracker.synchToPlayer(player);
 				return new ContainerPropolisPipe(player.inventory, PipeHelper.getPipe(world, x, y, z, PipeItemsPropolis.class));
 			}


### PR DESCRIPTION
`BeeManager.beeRoot` is not available until Forestry 3.6.0