### PR TITLE
Sensible name for the Refinery ZenMethod

### DIFF
--- a/common/buildcraft/compat/minetweaker/Refinery.java
+++ b/common/buildcraft/compat/minetweaker/Refinery.java
@@ -34,9 +34,26 @@ public class Refinery {
 	public static void addRecipe(ILiquidStack output, int energyPerMB, int ticksPerMB, ILiquidStack input1, @Optional ILiquidStack input2) {
 		MineTweakerAPI.apply(new AddRecipeAction(output, energyPerMB, ticksPerMB, input1, input2));
 	}
-
+	
 	@ZenMethod
 	public static void removeRecipe(ILiquidStack output) {
+		Fluid fluid = MineTweakerMC.getLiquidStack(output).getFluid();
+		
+		List<IFlexibleRecipe<FluidStack>> toRemove = new ArrayList<IFlexibleRecipe<FluidStack>>();
+		for (IFlexibleRecipe<FluidStack> recipe : BuildcraftRecipeRegistry.refinery.getRecipes()) {
+			if (recipe instanceof IFlexibleRecipeViewable && ((IFlexibleRecipeViewable) recipe).getOutput() == fluid) {
+				toRemove.add(recipe);
+			}
+		}
+		
+		for (IFlexibleRecipe<FluidStack> recipe : toRemove) {
+			MineTweakerAPI.apply(new RemoveRecipeAction(recipe));
+		}
+	}
+	
+	//Deprecated method for backwards compability
+	@ZenMethod
+	public static void remove(ILiquidStack output) {
 		Fluid fluid = MineTweakerMC.getLiquidStack(output).getFluid();
 		
 		List<IFlexibleRecipe<FluidStack>> toRemove = new ArrayList<IFlexibleRecipe<FluidStack>>();

--- a/common/buildcraft/compat/minetweaker/Refinery.java
+++ b/common/buildcraft/compat/minetweaker/Refinery.java
@@ -54,19 +54,9 @@ public class Refinery {
 	//Deprecated method for backwards compability
 	@ZenMethod
 	public static void remove(ILiquidStack output) {
-		Fluid fluid = MineTweakerMC.getLiquidStack(output).getFluid();
-		
-		List<IFlexibleRecipe<FluidStack>> toRemove = new ArrayList<IFlexibleRecipe<FluidStack>>();
-		for (IFlexibleRecipe<FluidStack> recipe : BuildcraftRecipeRegistry.refinery.getRecipes()) {
-			if (recipe instanceof IFlexibleRecipeViewable && ((IFlexibleRecipeViewable) recipe).getOutput() == fluid) {
-				toRemove.add(recipe);
-			}
-		}
-		
-		for (IFlexibleRecipe<FluidStack> recipe : toRemove) {
-			MineTweakerAPI.apply(new RemoveRecipeAction(recipe));
-		}
+	       removeRecipe(output);
 	}
+
 	
 	// ######################
 	// ### Action Classes ###

--- a/common/buildcraft/compat/minetweaker/Refinery.java
+++ b/common/buildcraft/compat/minetweaker/Refinery.java
@@ -36,7 +36,7 @@ public class Refinery {
 	}
 
 	@ZenMethod
-	public static void remove(ILiquidStack output) {
+	public static void removeRecipe(ILiquidStack output) {
 		Fluid fluid = MineTweakerMC.getLiquidStack(output).getFluid();
 		
 		List<IFlexibleRecipe<FluidStack>> toRemove = new ArrayList<IFlexibleRecipe<FluidStack>>();


### PR DESCRIPTION
Kind of self explanatory, the addRecipe method isn't called just "add" either :) Incase this PR gets accepted, you might want to note in the  changelog that if a person is using this method, they should rename it to "removeRecipe" to avoid errors.
