### PR TITLE
Add Ender Storage support

### DIFF
--- a/common/buildcraft/BuildCraftCompat.java
+++ b/common/buildcraft/BuildCraftCompat.java
@@ -97,6 +97,7 @@ public class BuildCraftCompat extends BuildCraftMod {
         this.offerModule(new CompatModuleBigReactors());
         this.offerModule(new CompatModuleFactorization());
         this.offerModule(new CompatModuleImmersiveEngineering());
+        this.offerModule(new CompatModuleEnderStorage());
 
         BuildCraftCompat.config.save();
 

--- a/common/buildcraft/compat/CompatModuleEnderStorage.java
+++ b/common/buildcraft/compat/CompatModuleEnderStorage.java
@@ -1,0 +1,24 @@
+package buildcraft.compat;
+
+import buildcraft.compat.enderstorage.SchematicTileEnderStorage;
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Optional;
+
+public class CompatModuleEnderStorage extends CompatModuleBase {
+    @Override
+    public String name() {
+        return "EnderStorage";
+    }
+
+    @Override
+    public void init() {
+        if (Loader.isModLoaded("EnderStorage")) {
+            initBuilders();
+        }
+    }
+
+    @Optional.Method(modid = "BuildCraft|Builders")
+    private void initBuilders() {
+        CompatUtils.registerSchematic("EnderStorage:enderChest", 0, 1, SchematicTileEnderStorage.class);
+    }
+}

--- a/common/buildcraft/compat/enderstorage/SchematicTileEnderStorage.java
+++ b/common/buildcraft/compat/enderstorage/SchematicTileEnderStorage.java
@@ -1,0 +1,34 @@
+package buildcraft.compat.enderstorage;
+
+import buildcraft.api.blueprints.IBuilderContext;
+import buildcraft.api.blueprints.SchematicTile;
+import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
+
+// Copy all NBT, including:
+// owner
+// freq
+// ir (if ender tank)
+public class SchematicTileEnderStorage extends SchematicTile {
+    @Override
+    public void rotateLeft(IBuilderContext context) {
+        if (tileNBT != null) {
+            tileNBT.setInteger("rot", (tileNBT.getInteger("rot") + 1) % 4);
+        }
+    }
+
+    @Override
+    public void storeRequirements(IBuilderContext context, int x, int y, int z) {
+        // ignore inventory contents (that's world state, not block state)
+        if (block != null) {
+            ArrayList<ItemStack> req = block.getDrops(context.world(), x,
+                    y, z, context.world().getBlockMetadata(x, y, z), 0);
+
+            if (req != null) {
+                storedRequirements = new ItemStack [req.size()];
+                req.toArray(storedRequirements);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Tested against EnderStorage 1.7.10-1.4.7.33:

Rotation works correctly (rot=2 to rot=0..3)
Frequency is copied; builder requires a chest with the same frequency
Owner is copied; builder requires a chest with the same owner
Ender tank's valve state is copied; builder is valve-state-agnostic (because the items don't save that state)
Ender chest's inventory state isn't copied
Ender chest's inventory state doesn't affect its requirements/cost

Note: SchematicTileEnderStorage.storeRequirements is literally a copy-paste job from the grandparent class; I couldn't think of a better option short of refactoring the world.
