### PR TITLE
Fix robots ignoring extremely mature Agricraft crops

### DIFF
--- a/common/buildcraft/compat/agricraft/CropHandlerAgriCraft.java
+++ b/common/buildcraft/compat/agricraft/CropHandlerAgriCraft.java
@@ -43,7 +43,7 @@ public class CropHandlerAgriCraft implements ICropHandler {
 	@Override
 	public boolean isMature(IBlockAccess blockAccess, Block block, int meta, int x, int y, int z) {
 		if (block.getUnlocalizedName().equals("tile.agricraft:crops")) {
-			return meta == 7;
+			return meta >= 7;
 		}
 		return false;
 	}


### PR DESCRIPTION
Crops left under several sprinklers will eventually be ignored by Harvester robots. Harvesting the crops by hand will make the Harvester pay attention to them again.

This one-character change should fix that.