### PR TITLE
Fix #80 - Late recipe addition on server join

### DIFF
--- a/common/buildcraft/compat/module/forestry/pipe/ForestryPipes.java
+++ b/common/buildcraft/compat/module/forestry/pipe/ForestryPipes.java
@@ -53,7 +53,7 @@ public class ForestryPipes {
     }
 
     @SubscribeEvent
-    public static void registerRecipes(RegistryEvent<IRecipe> event) {
+    public static void registerRecipes(RegistryEvent.Register<IRecipe> event) {
         Item propolis = ForgeRegistries.ITEMS.getValue(new ResourceLocation("forestry:propolis"));
         if (propolis != null && propolis != Items.AIR) {
             addPipeRecipe(pipeItemPropolis, propolis, Items.DIAMOND);


### PR DESCRIPTION
This little typo is causing `registerRecipes` to be called in response to a MissingMappings event.