### PR TITLE
remove support should cast Object to correct Type

### DIFF
--- a/common/buildcraft/compat/minetweaker/Refinery.java
+++ b/common/buildcraft/compat/minetweaker/Refinery.java
@@ -44,8 +44,10 @@ public class Refinery {
 		
 		List<IFlexibleRecipe<FluidStack>> toRemove = new ArrayList<IFlexibleRecipe<FluidStack>>();
 		for (IFlexibleRecipe<FluidStack> recipe : BuildcraftRecipeRegistry.refinery.getRecipes()) {
-			if (recipe instanceof IFlexibleRecipeViewable && ((IFlexibleRecipeViewable) recipe).getOutput() == fluid) {
-				toRemove.add(recipe);
+			if (recipe instanceof IFlexibleRecipeViewable && ((IFlexibleRecipeViewable) recipe).getOutput() instanceof FluidStack) {
+				if(fluid == ((FluidStack) ((IFlexibleRecipeViewable) recipe).getOutput()).getFluid()) {
+					toRemove.add(recipe);
+				}
 			}
 		}
 		


### PR DESCRIPTION
recipes output is Fluid Stack Type, and Minetweaker Scripts have Fluid Type. This change will make removing recipe scripts to work properly